### PR TITLE
Use short hand, introduce textwriter, standardize iowriter

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,8 @@ kubectl druid update --cr <cr> --image <image> --namespace <namespace> --node br
 kubectl druid patch --cr <cr> --namespace <namespace> --deleteOrphanPvc true
 kubectl druid patch --cr <cr> --namespace <namespace> --rollingDeploy true
 ```
+
+- Shorthand supported
+```
+- n for namespace
+```

--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -54,7 +54,7 @@ type dynamicInterface interface {
 // readers interface
 type readers interface {
 	listDruidCR(namespace string) (map[string][]string, error)
-	getDruidNodeNames(namespaces, cr string) (map[string][]string, error)
+	getDruidNodeNames(namespace, cr string) (map[string][]string, error)
 }
 
 // writers interface

--- a/cmd/patchers.go
+++ b/cmd/patchers.go
@@ -3,19 +3,14 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"io"
 	"strconv"
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
-type druidPatcherCmd struct {
-	out io.Writer
-}
-
 func druidCRPatcher(streams genericclioptions.IOStreams) *cobra.Command {
-	druidCmdList := &druidPatcherCmd{
+	druidCmdList := &druidIoWriter{
 		out: streams.Out,
 	}
 
@@ -33,15 +28,15 @@ func druidCRPatcher(streams genericclioptions.IOStreams) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	f.StringVar(&namespace, "namespace", "", "namespace of druid CR")
+	f.StringVarP(&namespace, "namespace", "n", "", "namespace of druid CR")
 	f.StringVar(&cr, "cr", "", "name of the druid CR")
-	f.StringVar(&deleteOrphanPvc, "deleteOrphanPvc", "", "deleteOrphanPvc is a bool, enabling to true will lead to delete of orphan pvc")
-	f.StringVar(&rollingDeploy, "rollingDeploy", "", "rollingDeploy is a bool, enabling to true will lead to sequential rolling upgrades")
+	f.StringVar(&deleteOrphanPvc, "deleteOrphanPvc", "", "deleteOrphanPvc, enabling to true will lead to delete of orphan pvc")
+	f.StringVar(&rollingDeploy, "rollingDeploy", "", "rollingDeploy, enabling to true will lead to sequential rolling upgrades")
 
 	return cmd
 }
 
-func (sv *druidPatcherCmd) druidCRPatcherRun(namespace, CR, deleteOrphanPvc, rollingDeploy string) error {
+func (sv *druidIoWriter) druidCRPatcherRun(namespace, CR, deleteOrphanPvc, rollingDeploy string) error {
 
 	if deleteOrphanPvc != "" {
 		b, _ := strconv.ParseBool(deleteOrphanPvc)

--- a/cmd/readers.go
+++ b/cmd/readers.go
@@ -3,7 +3,8 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"io"
+	"os"
+	"sort"
 
 	"github.com/spf13/cobra"
 
@@ -11,12 +12,8 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
-type druidListCmd struct {
-	out io.Writer
-}
-
 func druidCRList(streams genericclioptions.IOStreams) *cobra.Command {
-	druidCmdList := &druidListCmd{
+	druidCmdList := &druidIoWriter{
 		out: streams.Out,
 	}
 
@@ -34,29 +31,38 @@ func druidCRList(streams genericclioptions.IOStreams) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	f.StringVar(&namespace, "namespace", "", "namespace of druid CR")
+	f.StringVarP(&namespace, "namespace", "n", "", "namespace of druid CR")
 	return cmd
 }
 
-func (sv *druidListCmd) druidCRListRun(namespace, CR string, args []string) error {
+func (sv *druidIoWriter) druidCRListRun(namespace, CR string, args []string) error {
 
 	listDruids, err := di.listDruidCR(namespace)
 	if err != nil {
 		return err
 	}
 
-	for _, l := range listDruids {
-		_, err := fmt.Fprintf(sv.out, "%s\n", l)
-		if err != nil {
-			return err
+	// Format in tab-separated columns with a tab stop of 8.
+	sv.w.Init(os.Stdout, 0, 8, 0, '\t', 0)
+
+	fmt.Fprintf(&sv.w, "NAME\tNAMESPACE\t\n")
+
+	for namespace, crNames := range listDruids {
+		for _, crName := range crNames {
+			_, err := fmt.Fprintf(&sv.w, "%s\t%s\t\n", namespace, crName)
+			if err != nil {
+				return err
+			}
 		}
 	}
+
+	sv.w.Flush()
 
 	return nil
 }
 
 func druidCRGet(streams genericclioptions.IOStreams) *cobra.Command {
-	druidCmdList := &druidListCmd{
+	druidCmdList := &druidIoWriter{
 		out: streams.Out,
 	}
 
@@ -77,30 +83,39 @@ func druidCRGet(streams genericclioptions.IOStreams) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	f.StringVar(&namespace, "namespace", "", "namespace of druid CR")
+	f.StringVarP(&namespace, "namespace", "n", "", "namespace of druid CR")
 	f.StringVar(&cr, "cr", "", "name of druid CR")
 
 	return cmd
 }
 
-func (sv *druidListCmd) druidCRGetRun(namespace, cr string) error {
+func (sv *druidIoWriter) druidCRGetRun(namespace, cr string) error {
 
 	getDruidNodes, err := di.getDruidNodeNames(namespace, cr)
 	if err != nil {
 		return err
 	}
 
-	for _, l := range getDruidNodes {
-		_, err := fmt.Fprintf(sv.out, "%s\n", l)
-		if err != nil {
-			return err
+	// Format in tab-separated columns with a tab stop of 8.
+	sv.w.Init(os.Stdout, 0, 8, 0, '\t', 0)
+
+	fmt.Fprintf(&sv.w, "NAME\tNAMESPACE\t\n")
+
+	for namespace, nodeNames := range getDruidNodes {
+		for _, nodeName := range sort.StringSlice(nodeNames) {
+			_, err := fmt.Fprintf(&sv.w, "%s\t%s\t\n", nodeName, namespace)
+			if err != nil {
+				return err
+			}
 		}
 	}
+
+	sv.w.Flush()
 
 	return nil
 }
 
-func (sv *druidListCmd) validate(args []string) error {
+func (sv *druidIoWriter) validate(args []string) error {
 	if args == nil || args[0] != "nodes" {
 		return errors.New("invalid arg, valid arg is [nodes] e.g. 'kubectl druid get nodes --cr <cr> --namespace <namespace>'")
 	}

--- a/cmd/writers.go
+++ b/cmd/writers.go
@@ -3,18 +3,13 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"io"
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
-type druidWriterCmd struct {
-	out io.Writer
-}
-
 func druidCRWriterNodeSpecReplicas(streams genericclioptions.IOStreams) *cobra.Command {
-	writerCmd := &druidWriterCmd{
+	writerCmd := &druidIoWriter{
 		out: streams.Out,
 	}
 
@@ -41,15 +36,15 @@ func druidCRWriterNodeSpecReplicas(streams genericclioptions.IOStreams) *cobra.C
 	return cmd
 }
 
-func (sv *druidWriterCmd) druidCRWriterNodeSpecReplicasRun(nodeName, namespace, cr string, replica int64) error {
+func (sv *druidIoWriter) druidCRWriterNodeSpecReplicasRun(node, namespace, cr string, replica int64) error {
 
-	writerResult, err := di.writerDruidNodeSpecReplicas(nodeName, namespace, cr, replica)
+	writerResult, err := di.writerDruidNodeSpecReplicas(node, namespace, cr, replica)
 	if err != nil {
 		return err
 	}
 
 	if writerResult {
-		_, err := fmt.Fprintf(sv.out, "Druid CR [%s],NodeName [%s] successfully updated in Namespace [%s] with Replica Count [%d]\n", cr, nodeName, namespace, replica)
+		_, err := fmt.Fprintf(sv.out, "Druid CR [%s], Node [%s] successfully updated in Namespace [%s] with Replica Count [%d]\n", cr, node, namespace, replica)
 		if err != nil {
 			return err
 		}
@@ -59,7 +54,7 @@ func (sv *druidWriterCmd) druidCRWriterNodeSpecReplicasRun(nodeName, namespace, 
 }
 
 func druidCRWriterUpdates(streams genericclioptions.IOStreams) *cobra.Command {
-	writerCmd := &druidWriterCmd{
+	writerCmd := &druidIoWriter{
 		out: streams.Out,
 	}
 
@@ -87,15 +82,15 @@ func druidCRWriterUpdates(streams genericclioptions.IOStreams) *cobra.Command {
 	return cmd
 }
 
-func (sv *druidWriterCmd) druidCRWriterUpdatesRun(nodeName, namespace, cr, image string) error {
+func (sv *druidIoWriter) druidCRWriterUpdatesRun(node, namespace, cr, image string) error {
 
-	writerResult, err := di.writerDruidNodeImages(nodeName, namespace, cr, image)
+	writerResult, err := di.writerDruidNodeImages(node, namespace, cr, image)
 	if err != nil {
 		return err
 	}
 
 	if writerResult {
-		_, err := fmt.Fprintf(sv.out, "Druid CR [%s],NodeName [%s] successfully update with image [%s] in Namespace [%s]\n", cr, nodeName, image, namespace)
+		_, err := fmt.Fprintf(sv.out, "Druid CR [%s], Node [%s] successfully update with image [%s] in Namespace [%s]\n", cr, node, image, namespace)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fix #2

- supports -n as a shorthand for namespace
- textwriter library  shall space out stdouts to 8 tabs.
- all methods shall implement 
```
type druidIoWriter struct {
	out io.Writer
	w   tabwriter.Writer
}
```
- this way more extensible to add fields . 
- tabwriter is also implementation of io.writer
- get node and list methods shall return a map[string][]string{} ie ```map[namespace][]{nodenames}```
- output is sorted

@nishantmonu51 